### PR TITLE
26.2 port

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'net.fabricmc.fabric-loom' version '1.15.5' apply false
+    id 'net.fabricmc.fabric-loom' version '1.16-SNAPSHOT' apply false
     id 'net.neoforged.moddev' version '2.0.141' apply false
     id 'me.modmuss50.mod-publish-plugin' version '1.1.0' apply false
 }

--- a/buildSrc/src/main/groovy/multiloader-loader.gradle
+++ b/buildSrc/src/main/groovy/multiloader-loader.gradle
@@ -53,9 +53,7 @@ publishMods {
     curseforge {
         accessToken = providers.environmentVariable("CURSEFORGE_TOKEN")
         projectId = "1528600"
-        minecraftVersions.add("26.1")
-        minecraftVersions.add("26.1.1")
-        minecraftVersions.add("26.1.2")
+        minecraftVersions.add("26.2")
 
         optional("cloth-config")
         optional("trinkets")
@@ -65,9 +63,7 @@ publishMods {
     modrinth {
         accessToken = providers.environmentVariable("MODRINTH_TOKEN")
         projectId = "pVIWsXir"
-        minecraftVersions.add("26.1")
-        minecraftVersions.add("26.1.1")
-        minecraftVersions.add("26.1.2")
+        minecraftVersions.add("26.2")
 
         optional("cloth-config")
         optional("trinkets")

--- a/common/src/main/java/com/evandev/reliable_gliders/mixin/ItemInHandRendererMixin.java
+++ b/common/src/main/java/com/evandev/reliable_gliders/mixin/ItemInHandRendererMixin.java
@@ -29,7 +29,7 @@ public class ItemInHandRendererMixin {
     @Unique
     private boolean reliableGliders$modified = false;
 
-    @Inject(method = "renderHandsWithItems", at = @At("HEAD"))
+    @Inject(method = "submitHandsWithItems", at = @At("HEAD"))
     private void reliableGliders$setupGliderHands(float frameInterp, PoseStack poseStack, SubmitNodeCollector submitNodeCollector, LocalPlayer player, int lightCoords, CallbackInfo ci) {
         if (GlidingState.isGliding(player)) {
             boolean holdingGlider = this.mainHandItem.is(ModItems.GLIDER) || this.offHandItem.is(ModItems.GLIDER);
@@ -45,7 +45,7 @@ public class ItemInHandRendererMixin {
         }
     }
 
-    @Inject(method = "renderHandsWithItems", at = @At("TAIL"))
+    @Inject(method = "submitHandsWithItems", at = @At("TAIL"))
     private void reliableGliders$restoreGliderHands(float frameInterp, PoseStack poseStack, SubmitNodeCollector submitNodeCollector, LocalPlayer player, int lightCoords, CallbackInfo ci) {
         if (this.reliableGliders$modified) {
             this.mainHandItem = this.reliableGliders$storedMain;

--- a/fabric/src/main/java/com/evandev/reliable_gliders/platform/FabricPlatformHelper.java
+++ b/fabric/src/main/java/com/evandev/reliable_gliders/platform/FabricPlatformHelper.java
@@ -5,14 +5,12 @@ import com.evandev.reliable_gliders.item.GliderItem;
 import com.evandev.reliable_gliders.platform.services.IPlatformHelper;
 import com.evandev.reliable_gliders.registry.ModItems;
 import eu.pb4.trinkets.api.TrinketAttachment;
-import eu.pb4.trinkets.api.TrinketSlotAccess;
 import eu.pb4.trinkets.api.TrinketsApi;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.Item;
-import net.minecraft.world.item.ItemStack;
 
 import java.nio.file.Path;
 
@@ -63,12 +61,9 @@ public class FabricPlatformHelper implements IPlatformHelper {
         if (isModLoaded("trinkets") && player instanceof ServerPlayer serverPlayer) {
             TrinketAttachment attachment = TrinketsApi.getAttachment(player);
             if (attachment != null) {
-                attachment.getEquipped(ModItems.GLIDER).forEach(match -> {
-                    ItemStack stack = match.getB();
-                    TrinketSlotAccess slot = match.getA();
-
-                    TrinketsApi.hurtAndBreakItemStack(stack, 1, serverPlayer, slot);
-                });
+                attachment.equipped(ModItems.GLIDER, false).forEach(slot ->
+                        TrinketsApi.hurtAndBreakItemStack(slot.get(), 1, serverPlayer, slot)
+                );
             }
         }
     }

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -36,7 +36,7 @@
   "depends": {
     "fabricloader": ">=${fabric_loader_version}",
     "fabric-api": "*",
-    "minecraft": ">=26.1 <=26.2",
+    "minecraft": ">=26.2 <=26.3",
     "java": ">=${java_version}"
   },
   "suggests": {

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,29 +4,29 @@ group=com.evandev.reliable_gliders
 java_version=25
 
 # Common
-minecraft_version=26.1.2
+minecraft_version=26.2
 mod_name=Reliable Gliders
 mod_author=Evan
 mod_id=reliable_gliders
 license=MIT
 credits=Art by noelledotjpg!
 description=Simple, vanilla-friendly Gliders for Minecraft!
-minecraft_version_range=[26.1, 26.2)
-neo_form_version=26.1-1
+minecraft_version_range=[26.2, 26.3)
+neo_form_version=26.2-2
 
 # Dependencies
-cloth_config_version=26.1.154
-mod_menu_version=18.0.0-alpha.8
-rrv_version=7.1.4+26.1.1
-curios_version=15.0.0-beta.2+26.1.2
-trinkets_version=4.0.0-alpha.9+26.1
+cloth_config_version=26.2.155
+mod_menu_version=20.0.0-beta.4
+rrv_version=8.6.3+26.2
+curios_version=15.0.0+26.1.2
+trinkets_version=4.1.0-beta.2+26.2
 
 # Fabric
-fabric_version=0.145.4+26.1.1
-fabric_loader_version=0.18.4
+fabric_version=0.155.2+26.2
+fabric_loader_version=0.19.3
 
 # NeoForge
-neoforge_version=26.1.0.19-beta
+neoforge_version=26.2.0.25-beta
 neoforge_loader_version_range=[4,)
 
 # Gradle

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/neoforge/build.gradle
+++ b/neoforge/build.gradle
@@ -48,7 +48,7 @@ dependencies {
     implementation "me.shedaniel.cloth:cloth-config-neoforge:${cloth_config_version}"
 
     // Curios
-    implementation "maven.modrinth:curios:${curios_version}"
+    compileOnly "maven.modrinth:curios:${curios_version}"
 }
 
 def loaderAttribute = Attribute.of('io.github.mcgradleconventions.loader', String)


### PR DESCRIPTION
- Updated `ItemInHandRendererMixin`
- Updated Trinkets compat for the API breakage in 4.1.0
- Set Curios to `compileOnly` as it doesn't have a 26.2 version yet (API is unlikely to change)